### PR TITLE
Gracefully termination with informative error message.

### DIFF
--- a/git-also.js
+++ b/git-also.js
@@ -18,8 +18,21 @@ if (program.args.length !== 1) {
 
 // Only commits that have this file will be counted:
 var fileLookup = path.resolve(program.args[0])
-var dirName = path.dirname(fileLookup);
-process.chdir(dirName);
+
+// Change working directory based on input path
+try {
+    var dirName = path.dirname(fileLookup);
+    process.chdir(dirName);
+} catch(error) {
+    if (error.code === 'ENOENT') {
+        console.log('no such directory: ' + dirName);
+        process.exitCode = 1;
+    } else {
+        // re-raise the error if it's not an ENOENT
+        throw(error);
+    }
+    return;
+}
 
 fileLookup = path.normalize(fileLookup);
 // in cygwin/windows the lookup path is "Root\Lib\file.c", while git shows it as


### PR DESCRIPTION
This PR adds graceful termination in the case that a path directory does not exist.
Currently, a traceback is thrown:
```bash
$ node git-also.js foo/bar.js
/some/path/git-also/git-also.js:22
process.chdir(dirName);
        ^

Error: ENOENT: no such file or directory, uv_chdir
    at Object.<anonymous> (/some/path/git-also/git-also.js:22:9)
    at Module._compile (module.js:571:32)
    at Object.Module._extensions..js (module.js:580:10)
    at Module.load (module.js:488:32)
    at tryModuleLoad (module.js:447:12)
    at Function.Module._load (module.js:439:3)
    at Module.runMain (module.js:605:10)
    at run (bootstrap_node.js:420:7)
    at startup (bootstrap_node.js:139:9)
    at bootstrap_node.js:535:3
```

With this PR, the user will get an informative error message (no traceback) and the appropriate exit code of 1.
Running it again will show:
```bash
$ node git-also.js foo/bar.js
no such directory: /some/path/git-also/foo
```